### PR TITLE
Updated documentation to run examples successfully in the working env…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See <https://opentelemetry.io/docs/collector/deployment>
 
 - BMC monitoring (temp, power)
   - Redfish extention for OTEL collector can be used to collect HW/BMC related metrics like temperature, power and others...
-  - For testing using mockup : `docker run --rm dmtf/redfish-mockup-server:1.1.8`
+  - For testing using mockup : `docker run --rm --net=host dmtf/redfish-mockup-server:1.1.8`
 
 - TBD
   - OPI wants to define which telemetries are mandatory for each vendor to implement and which are optional

--- a/config/telegraf.conf
+++ b/config/telegraf.conf
@@ -40,6 +40,7 @@
   data_format = "influx"
 
 [[outputs.opentelemetry]]
+  # Use either host name or the IP address for service_address
   service_address = "otel-gw-collector:4317"
 
 [[outputs.influxdb_v2]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,8 @@ services:
       - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
     networks:
       - opi
+    ports:
+      - "80:80"
     healthcheck:
       test: ["CMD-SHELL", "wget -O /dev/null http://localhost || exit 1"]
       timeout: 10s


### PR DESCRIPTION
The purpose of this PR is to implement the following changes:

1. A minor adjustment to the execution of the Redfish server command `docker run --rm --net=host dmtf/redfish-mockup-server:1.1.8` to utilize the host's network stack.

2. An update to the "docker-compose.yml" file to establish port mappings between the host machine and the Docker container.